### PR TITLE
program: Dont hardcode the endpoint address but find the first out endpoint

### DIFF
--- a/program.py
+++ b/program.py
@@ -48,7 +48,15 @@ try:
     if dev.is_kernel_driver_active(0):
         dev.detach_kernel_driver(0)
     interface = dev.configurations()[0].interfaces()[0]
-    endpoint = usb.util.find_descriptor(interface, bEndpointAddress=1)
+    cfg = dev.get_active_configuration()
+    intf = cfg[(0,0)]
+    endpoint = usb.util.find_descriptor(
+        intf,
+        # match the first OUT endpoint
+        custom_match = \
+        lambda e:
+            usb.util.endpoint_direction(e.bEndpointAddress) == \
+            usb.util.ENDPOINT_OUT)
 except Exception as err:
     error('Could not configure the device: %s' % err)
 try:


### PR DESCRIPTION
Some of the older and newer tags use different USB chips und the same brand. They differentiate in usb descriptor configuration which is causing the programm command to fail as the descriptor is never found.

This is fixing it by using the lambda as proposed by @ngkz to find the first valid OUT descriptor.
https://github.com/jnweiger/led-name-badge-ls32/issues/41#issuecomment-1786602203